### PR TITLE
Allow uid:gid to be set via docker run

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.13
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
 ENV TS_DIRECTORY=/opt/teamspeak

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.13
-MAINTAINER Matt Bentley <mbentley@mbentley.net>
+LABEL version="1.0" maintainer="Matt Bentley <mbentley@mbentley.net>" maintainer="Chad Hutchins <chadhutchins182@users.noreply.github.com>"
 
 ENV TS_DIRECTORY=/opt/teamspeak
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -17,9 +17,12 @@ RUN apk add --no-cache bzip2 ca-certificates coreutils libstdc++ tini w3m &&\
   apk del bzip2 w3m
 
 # create user, group, and set permissions
-RUN adduser -u 503 -g 503 -h ${TS_DIRECTORY} -D teamspeak &&\
-  mkdir /data &&\
-  chown -R teamspeak:teamspeak ${TS_DIRECTORY} /data
+RUN  echo "**** create teamspeak user and make our folders ****" && \
+ groupmod -g 1000 users && \
+ useradd -u 503 -U -d ${TS_DIRECTORY} -s /bin/false teamspeak && \
+ usermod -G users teamspeak && \
+ mkdir /data &&\
+ chown -R teamspeak:teamspeak ${TS_DIRECTORY} /data
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.13
-LABEL version="1.0" maintainer="Matt Bentley <mbentley@mbentley.net>" maintainer="Chad Hutchins <chadhutchins182@users.noreply.github.com>"
+FROM alpine:latest
+LABEL version="1.0" maintainer="Matt Bentley <mbentley@mbentley.net>" 
 
 ENV TS_DIRECTORY=/opt/teamspeak
 
@@ -7,7 +7,7 @@ ENV TS_DIRECTORY=/opt/teamspeak
 ARG TS_SERVER_VER
 
 # install the latest teamspeak
-RUN apk add --no-cache bzip2 ca-certificates coreutils libstdc++ tini w3m &&\
+RUN apk add --no-cache bzip2 ca-certificates coreutils libstdc++ tini w3m shadow &&\
   TS_SERVER_VER="$(w3m -dump https://www.teamspeak.com/downloads | grep -m 1 'Server 64-bit ' | awk '{print $NF}')" &&\
   wget https://files.teamspeak-services.com/releases/server/${TS_SERVER_VER}/teamspeak3-server_linux_alpine-${TS_SERVER_VER}.tar.bz2 -O /tmp/teamspeak.tar.bz2 &&\
   mkdir -p /opt &&\
@@ -18,14 +18,15 @@ RUN apk add --no-cache bzip2 ca-certificates coreutils libstdc++ tini w3m &&\
 
 # create user, group, and set permissions
 RUN  echo "**** create teamspeak user and make our folders ****" && \
- groupmod -g 1000 users && \
- useradd -u 503 -U -d ${TS_DIRECTORY} -s /bin/false teamspeak && \
- usermod -G users teamspeak && \
- mkdir /data &&\
- chown -R teamspeak:teamspeak ${TS_DIRECTORY} /data
+  adduser -h ${TS_DIRECTORY} -s /bin/false -D teamspeak && \
+  PUID=${PUID:-911} && \
+  PGID=${PGID:-911} && \
+  groupmod -o -g "$PGID" teamspeak && \
+  usermod -o -u "$PUID" teamspeak && \
+  [[ -d /data ]] || mkdir /data 
 
 COPY entrypoint.sh /entrypoint.sh
 
-USER teamspeak
+# USER teamspeak
 EXPOSE 9987/udp 10011 30033 41144
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
As requested in #29 I implemented a way for the alpine version to pass in `-e PUID=1000 -e PGID=1000` just like linuxserver.io images. In fact the way I made this work was to use `ghcr.io/linuxserver/baseimage-alpine-nginx:3.13`.

Also removed `MAINTAINER `tag as it is deprecated and used `LABEL `instead. 

I can change the README.md as well but I was hoping to get some feedback first. Also I haven't done anything to the debian version.

Example run command:
```shell
docker run -d --restart=always --name teamspeak \
   -e TS3SERVER_LICENSE=accept \
   -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -p 41144:41144 \
   -e PUID=1000 -e PGID=1000 \
   -v /home/ec2-user/DOCKER/data/teamspeak:/data \
   chadhutchins182/teamspeak3:latest
```